### PR TITLE
chore(Renovate): use develop branch for Renovate Bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,19 +1,21 @@
 {
-  "extends": [
-    "config:base",
-    "config:js-lib",
-    ":semanticCommitScope(dependencies)"
-  ],
-  "updateLockFiles": true,
-  "packageRules": [
-    {
-      "packageNames": [
-        "@types/node"
-      ],
-      "major": {
-        "enabled": true
-      }
-    }
-  ]
+    "extends": [
+        "config:base",
+        "config:js-lib",
+        ":semanticCommitScope(dependencies)"
+    ],
+    "updateLockFiles": true,
+    "baseBranches": [
+        "develop"
+    ],
+    "packageRules": [
+        {
+            "packageNames": [
+                "@types/node"
+            ],
+            "major": {
+                "enabled": true
+            }
+        }
+    ]
 }
-


### PR DESCRIPTION
The Renovate Bot should use the develop branch and not the master branch.